### PR TITLE
Tone down global check noise

### DIFF
--- a/koabot/koakuma.py
+++ b/koabot/koakuma.py
@@ -97,10 +97,11 @@ def load_all_extensions(path: str):
 async def debug_check(ctx):
     """Disable live instance for specific users if a beta instance is running"""
 
-    if ctx.author.id not in bot.testing['debug_users']:
-        return True
-
     beta_bot_id = bot.koa['discord_user']['beta_id']
+
+    if ctx.author.id not in bot.testing['debug_users']:
+        return ctx.guild.me.id != beta_bot_id
+
     beta_bot = ctx.guild.get_member(beta_bot_id)
 
     if beta_bot and beta_bot.status == discord.Status.online:

--- a/koabot/koakuma.py
+++ b/koabot/koakuma.py
@@ -94,13 +94,18 @@ def load_all_extensions(path: str):
 
 
 @bot.check
-async def beta_check(ctx):
-    """Disable live instance if a beta instance is running"""
+async def debug_check(ctx):
+    """Disable live instance for specific users if a beta instance is running"""
+
+    if ctx.author.id not in bot.testing['debug_users']:
+        return True
+
     beta_bot_id = bot.koa['discord_user']['beta_id']
     beta_bot = ctx.guild.get_member(beta_bot_id)
 
     if beta_bot and beta_bot.status == discord.Status.online:
         return ctx.guild.me.id == beta_bot_id
+
     return True
 
 


### PR DESCRIPTION
It hasn't been completely eliminated, but it's now hugely reduced as the check spam won't clutter in the live instance, instead piling up in debug instances, which is preferable.